### PR TITLE
Use/Reusable Container with Navbar and Header

### DIFF
--- a/frontend/src/components/BestDesignQuality/index.jsx
+++ b/frontend/src/components/BestDesignQuality/index.jsx
@@ -28,7 +28,7 @@ const BestDesignQuality = () => {
       <Container
         margin={CONTAINER_OPTIONS.MARGIN.TOP}
         isBgGray
-        classNames="text-c300"
+        className="text-c300"
         padding={CONTAINER_OPTIONS.PADDING.MOB_PADDING}
       >
         <div className="grid grid-cols-1 lg:grid-cols-2 lg:gap-16 justify-center">

--- a/frontend/src/components/EstimateSection/index.jsx
+++ b/frontend/src/components/EstimateSection/index.jsx
@@ -19,7 +19,7 @@ const EstimateSection = () => {
     const backImg = {
       backgroundImage: `url(${desktopImage})`,
       backgroundRepeat: 'no-repeat',
-      backgroundSize: "cover",
+      backgroundSize: 'cover',
       backgroundPosition: 'right',
       height: 'auto',
       width: '100%',
@@ -30,19 +30,20 @@ const EstimateSection = () => {
         padding={CONTAINER_OPTIONS.PADDING.BIG}
         margin={CONTAINER_OPTIONS.MARGIN.TOW_SIDES}
         inlineStyle={backImg}
-        classNames="lg:text-left text-center py-32 h-auto text-c200"
       >
-        <span className="text-lg">{title}</span>
-        <Heading as="h6" className="my-5">
-          {subTitle}
-        </Heading>
-        <Button
-          bgColor="c100"
-          rounded={true}
-          customClassNames="lg:my-4 my-0 block w-56 h-16 lg:mx-0 mx-auto"
-        >
-          {button.label}
-        </Button>
+        <div className="lg:text-left text-center h-auto text-c200">
+          <span className="text-lg">{title}</span>
+          <Heading as="h6" className="my-5">
+            {subTitle}
+          </Heading>
+          <Button
+            bgColor="c100"
+            rounded={true}
+            customClassNames="lg:my-4 my-0 block w-56 h-16 lg:mx-0 mx-auto"
+          >
+            {button.label}
+          </Button>
+        </div>
       </Container>
     );
   } else {

--- a/frontend/src/components/Header/index.jsx
+++ b/frontend/src/components/Header/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Button } from './../shared/button/index.js';
 import { Heading, HEADING_OPTIONS } from '../shared/heading';
+import { Container, CONTAINER_OPTIONS } from '../shared/container';
 import { useEffect, useState } from 'react';
 import { API } from '../../modules/apis';
 
@@ -13,7 +14,10 @@ const Header = () => {
   }, []);
   if (data) {
     return (
-      <header className="w-ful pt-8 relative border-b-4 border-c100 md:border-none">
+      <Container
+        padding={CONTAINER_OPTIONS.PADDING.DEFAULT}
+        className=" relative border-b-4 border-c100 md:border-none"
+      >
         <div
           style={{ clipPath: 'polygon(0 0, 99.8% 0, 54.8% 99.5%, 0 99.5%)' }}
           className="hidden md:block z-10 absolute top-0 left-0 w-full h-full bg-c400 "
@@ -22,7 +26,7 @@ const Header = () => {
           style={{ clipPath: 'polygon(0 0, 100% 0, 55% 100%, 0 100%)' }}
           className="hidden md:block z-0 absolute top-0 left-0 w-full h-full bg-c100 opacity-25"
         ></div>
-        <div className="md:container m-auto w-11/12 sm:w-10/12 z-20 flex flex-row relative">
+        <div className="m-auto z-20 flex flex-row relative">
           <div className="w-70 m-auto lg:ml-16 lg:mr-32 lg:mt-8 xl:m-auto xl:w-auto xl:my-32">
             <div>
               <span className="text-c100 font-body text-lg xl:text-xxlg font-medium leading-1">
@@ -66,7 +70,7 @@ const Header = () => {
               </Button>
             </div>
           </div>
-          <div className="hidden sm:block w-1/2 mb-8 pb-8 md:ml-6 xl:mt-16">
+          <div className="hidden sm:block w-1/2 mb-8 pb-8 md:ml-6">
             <img
               src={data.dotsUrl}
               alt="dots"
@@ -79,7 +83,7 @@ const Header = () => {
             />
           </div>
         </div>
-      </header>
+      </Container>
     );
   } else {
     return null;

--- a/frontend/src/components/Navbar/index.jsx
+++ b/frontend/src/components/Navbar/index.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { API } from '../../modules/apis';
 import { Button } from '../shared/button';
+import { Container } from '../shared/container';
 
 export const Navbar = () => {
   const [data, setData] = useState(null);
@@ -17,9 +18,6 @@ export const Navbar = () => {
   }, []);
   const toggleMobileNav = () => {
     setMobileNavState(!mobileNavState);
-    // mobileNavState === 'hidden'
-    //   ? setMobileNavState('')
-    //   : setMobileNavState('hidden');
   };
   if (data) {
     const navLinks = data.linksList.map(({ title, linkUrl, id }) => {
@@ -33,7 +31,11 @@ export const Navbar = () => {
       );
     });
     return (
-      <div className="bg-c400 shadow-lg md:pb-6 lg:p-6 w-screen ">
+      <Container
+        widthOutContainerDiv
+        isBgGray
+        className="shadow-lg w-screen lg:py-8"
+      >
         <nav className="flex items-center justify-between bg-white shadow-lg p-3 lg:rounded-full lg:m-auto lg:w-4/5 xl:min-w-navbar">
           <div className="mx-2 sm:mx-6 md:mx:8 lg:mx-10">
             <img src={data.logoUrl} alt="logo" className="w-16" />
@@ -95,7 +97,7 @@ export const Navbar = () => {
             </li>
           </ul>
         </div>
-      </div>
+      </Container>
     );
   } else {
     return null;

--- a/frontend/src/components/shared/container/index.jsx
+++ b/frontend/src/components/shared/container/index.jsx
@@ -22,14 +22,14 @@ export const Container = ({
   padding,
   margin,
   isBgGray,
-  classNames,
-  inlineStyle
+  className,
+  inlineStyle,
+  widthOutContainerDiv
 }) => {
   return (
     <section
       style={inlineStyle}
       className={cn(
-        '',
         {
           'py-0': padding === CONTAINER_OPTIONS.PADDING.ZERO,
           'py-8': padding === CONTAINER_OPTIONS.PADDING.DEFAULT,
@@ -42,10 +42,12 @@ export const Container = ({
           'mb-12': margin === CONTAINER_OPTIONS.MARGIN.BOTTOM,
           'bg-c400': isBgGray
         },
-        classNames
+        className
       )}
     >
-      <div className="container mx-auto">{children}</div>
+      <div className={cn(
+        {"container mx-auto" : !widthOutContainerDiv}
+      )}>{children}</div>
     </section>
   );
 };


### PR DESCRIPTION
**what is did**
- add a property to the reusable container called `withOutContainerDiv` to remove the container class name from the inner div yo use with the navbar
- changed the property `classNames` to be `className` without `s` at the reusable container. 

> and change it at the used states

- used the reusable container with navbar and heading components
- fixed the used cases of reuable container, to use it the right way