### PR TITLE
estimate-api

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -7,9 +7,10 @@ import { LinksModule } from './links/links.module';
 import { MongooseModule } from  '@nestjs/mongoose';
 import { HttpErrorFilter } from './shared/http-error.filter';
 // import { HeaderModule } from './header/header.module';
+import { EstimateModule } from './estimate/estimate.module';
 
 @Module({
-  imports: [LinksModule, MongooseModule.forRoot(process.env.MONGO_URI)],
+  imports: [LinksModule, MongooseModule.forRoot(process.env.MONGO_URI), EstimateModule],
   controllers: [AppController],
   providers: [AppService, {
     provide: APP_FILTER,

--- a/api/src/estimate/dto/estimate.dto.ts
+++ b/api/src/estimate/dto/estimate.dto.ts
@@ -1,0 +1,5 @@
+export class EstimateDto {
+  readonly title: string;
+  readonly subTitle: string;
+  readonly img: string;
+}

--- a/api/src/estimate/entity/estimate.entity.ts
+++ b/api/src/estimate/entity/estimate.entity.ts
@@ -1,0 +1,7 @@
+import { Document } from 'mongoose';
+
+export interface Estimate extends Document {
+  title: string;
+  subTitle: string;
+  img: string;
+}

--- a/api/src/estimate/estimate.controller.spec.ts
+++ b/api/src/estimate/estimate.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EstimateController } from './estimate.controller';
+
+describe('EstimateController', () => {
+  let controller: EstimateController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [EstimateController],
+    }).compile();
+
+    controller = module.get<EstimateController>(EstimateController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/api/src/estimate/estimate.controller.ts
+++ b/api/src/estimate/estimate.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from '@nestjs/common';
+import { EstimateService } from './estimate.service';
+import { Estimate } from './entity/estimate.entity';
+
+@Controller('estimate')
+export class EstimateController {
+  constructor(private readonly estimateService: EstimateService) {}
+
+  @Get()
+  async find(): Promise<Estimate[]> {
+    return this.estimateService.find();
+  }
+}

--- a/api/src/estimate/estimate.module.ts
+++ b/api/src/estimate/estimate.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { EstimateSchema } from 'src/models/estimate.schema';
+import { EstimateController } from './estimate.controller';
+import { EstimateService } from './estimate.service';
+
+@Module({
+  imports: [MongooseModule.forFeature([{ name: 'Estimate', schema: EstimateSchema }])],
+  controllers: [EstimateController],
+  providers: [EstimateService]
+})
+export class EstimateModule {}

--- a/api/src/estimate/estimate.service.spec.ts
+++ b/api/src/estimate/estimate.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EstimateService } from './estimate.service';
+
+describe('EstimateService', () => {
+  let service: EstimateService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [EstimateService],
+    }).compile();
+
+    service = module.get<EstimateService>(EstimateService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/api/src/estimate/estimate.service.ts
+++ b/api/src/estimate/estimate.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { Estimate } from './entity/estimate.entity';
+import { Model } from 'mongoose';
+import { InjectModel } from '@nestjs/mongoose';
+
+@Injectable()
+export class EstimateService {
+  constructor(@InjectModel('Estimate') private readonly estimateModel: Model<Estimate>) {}
+
+  async find(): Promise<Estimate[]> {
+    return await this.estimateModel.find();
+  }
+}

--- a/api/src/models/estimate.schema.ts
+++ b/api/src/models/estimate.schema.ts
@@ -1,0 +1,7 @@
+import * as mongoose from 'mongoose';
+
+export const EstimateSchema = new mongoose.Schema({
+  title: String,
+  subTitle: String,
+  img: String,
+});


### PR DESCRIPTION
# Estimate-Section API
## _Description_
 API to  retrieve Estimate-section from a mongodb database.
this is the first update to be compatible with the JSON server db. 

### Stack:
We used Nestjs - in typescript -and Mongodb as a databases.

### Request Body:
```````
{
    "title":  "your-title",
    "subTitle":  "brief-desc",
    "img": "img-url"
}
```````

### Requests:  
we have these requests available:
- GET `localhost:3001/estimate` to get estimate-section

### Tasks to complete:
- [x] Estimate-Endpoints to db