### PR TITLE
new-about-api

### DIFF
--- a/api/src/about/about.controller.spec.ts
+++ b/api/src/about/about.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AboutController } from './about.controller';
+
+describe('AboutController', () => {
+  let controller: AboutController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AboutController],
+    }).compile();
+
+    controller = module.get<AboutController>(AboutController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/api/src/about/about.controller.ts
+++ b/api/src/about/about.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from '@nestjs/common';
+import { AboutService } from './about.service';
+import { About } from './entity/about.entity';
+
+@Controller('about')
+export class AboutController {
+  constructor(private readonly aboutService: AboutService) {};
+
+  @Get()
+  async find(): Promise<About[]> {
+    return this.aboutService.find();
+  }
+}

--- a/api/src/about/about.module.ts
+++ b/api/src/about/about.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { AboutSchema } from 'src/models/about.schema';
+import { AboutController } from './about.controller';
+import { AboutService } from './about.service';
+
+@Module({
+  imports: [MongooseModule.forFeature([{ name: 'About', schema: AboutSchema }])],
+  controllers: [AboutController],
+  providers: [AboutService]
+})
+export class AboutModule {}

--- a/api/src/about/about.service.spec.ts
+++ b/api/src/about/about.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AboutService } from './about.service';
+
+describe('AboutService', () => {
+  let service: AboutService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AboutService],
+    }).compile();
+
+    service = module.get<AboutService>(AboutService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/api/src/about/about.service.ts
+++ b/api/src/about/about.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { About } from './entity/about.entity';
+import { Model } from 'mongoose';
+import { InjectModel } from '@nestjs/mongoose';
+
+@Injectable()
+export class AboutService {
+  constructor(@InjectModel('About') private readonly aboutModel: Model<About>) {}
+
+  async find(): Promise<About[]> {
+    return await this.aboutModel.find();
+  }
+}

--- a/api/src/about/dto/about.dto.ts
+++ b/api/src/about/dto/about.dto.ts
@@ -1,0 +1,12 @@
+export class AboutDto {
+  readonly title: string;
+  readonly description: string;
+  readonly img: string;
+  readonly skills: [
+    {
+      readonly id: string;
+      readonly level: number;
+      readonly label: string;
+    }
+  ];
+}

--- a/api/src/about/entity/about.entity.ts
+++ b/api/src/about/entity/about.entity.ts
@@ -1,0 +1,14 @@
+import { Document } from 'mongoose';
+
+export interface About extends Document {
+  title: string;
+  description: string;
+  img: string;
+  skills: [
+    {
+      id: string,
+      level: number,
+      label: string;
+    }
+  ];
+}

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -7,9 +7,10 @@ import { LinksModule } from './links/links.module';
 import { MongooseModule } from  '@nestjs/mongoose';
 import { HttpErrorFilter } from './shared/http-error.filter';
 // import { HeaderModule } from './header/header.module';
+import { AboutModule } from './about/about.module';
 
 @Module({
-  imports: [LinksModule, MongooseModule.forRoot(process.env.MONGO_URI)],
+  imports: [LinksModule, MongooseModule.forRoot(process.env.MONGO_URI), AboutModule],
   controllers: [AppController],
   providers: [AppService, {
     provide: APP_FILTER,

--- a/api/src/models/about.schema.ts
+++ b/api/src/models/about.schema.ts
@@ -1,0 +1,21 @@
+import * as mongoose from 'mongoose';
+
+export const AboutSchema = new mongoose.Schema({
+  title: String,
+  description: String,
+  img: String,
+  skills: [
+    {
+      id: String,
+      level: {
+        type: Number,
+        min: 0,
+        max: 100,
+      },
+      label: {
+        type: String,
+        required: [true, 'Skill must have a name to descripe it']
+      }
+    }
+  ]
+});


### PR DESCRIPTION
# About-Section API
## _Description_
 API to  retrieve About-section from a mongodb database.
this is the first update to be compatible with the JSON server db. 

### Stack:
We used Nestjs - in typescript -and Mongodb as a databases.

### Request Body:
```````
{
    "title":  "your-title",
    "description":  "brief-desc",
    "img": "img-url",
    "skills": [
        {
            "id": "skill-id",
            "level": 45,
            "label": "skill-label"
        }
    ]
}
```````

### Requests:  
we have these requests available:
- GET `localhost:3001/about` to get about section

### Tasks to complete:
- [x] AboutUs-Endpoints to db