### PR TITLE
services-api

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -7,9 +7,10 @@ import { LinksModule } from './links/links.module';
 import { MongooseModule } from  '@nestjs/mongoose';
 import { HttpErrorFilter } from './shared/http-error.filter';
 // import { HeaderModule } from './header/header.module';
+import { ServicesModule } from './services/services.module';
 
 @Module({
-  imports: [LinksModule, MongooseModule.forRoot(process.env.MONGO_URI)],
+  imports: [LinksModule, MongooseModule.forRoot(process.env.MONGO_URI), ServicesModule],
   controllers: [AppController],
   providers: [AppService, {
     provide: APP_FILTER,

--- a/api/src/models/card.schema.ts
+++ b/api/src/models/card.schema.ts
@@ -1,0 +1,13 @@
+import * as mongoose from 'mongoose';
+
+export const CardSchema = new mongoose.Schema({
+  title: {
+    type: String,
+    required: [true, 'card must have a title']
+  },
+  description: {
+    type: String,
+    required: [true, 'You should describe your service'],
+    minLength: 20,
+  }
+});

--- a/api/src/models/services.schema.ts
+++ b/api/src/models/services.schema.ts
@@ -1,0 +1,12 @@
+import * as mongoose from 'mongoose';
+
+export const ServicesSchema = new mongoose.Schema({
+  title: {
+    type: String,
+    required: [true, 'Service must have a title'],
+  },
+  cards: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Card'
+  }
+});

--- a/api/src/services/dto/card.dto.ts
+++ b/api/src/services/dto/card.dto.ts
@@ -1,0 +1,4 @@
+export class CardDto {
+  readonly title: string;
+  readonly description: string;
+}

--- a/api/src/services/dto/services.dto.ts
+++ b/api/src/services/dto/services.dto.ts
@@ -1,0 +1,6 @@
+import { CardDto } from "./card.dto";
+
+export class ServicesDto {
+  readonly title: string;
+  readonly cards: CardDto[];
+}

--- a/api/src/services/entity/card.entity.ts
+++ b/api/src/services/entity/card.entity.ts
@@ -1,0 +1,6 @@
+import { Document } from 'mongoose';
+
+export interface Card extends Document {
+  title: string;
+  description: string;
+}

--- a/api/src/services/entity/services.entity.ts
+++ b/api/src/services/entity/services.entity.ts
@@ -1,0 +1,7 @@
+import { Document } from 'mongoose';
+import { Card } from './card.entity';
+
+export interface Services extends Document {
+  title: string;
+  cards: Card[];
+}

--- a/api/src/services/services.controller.spec.ts
+++ b/api/src/services/services.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ServicesController } from './services.controller';
+
+describe('ServicesController', () => {
+  let controller: ServicesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ServicesController],
+    }).compile();
+
+    controller = module.get<ServicesController>(ServicesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/api/src/services/services.controller.ts
+++ b/api/src/services/services.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from '@nestjs/common';
+import { ServicesService } from './services.service';
+import { Services } from './entity/services.entity';
+
+@Controller('services')
+export class ServicesController {
+  constructor(private readonly servService: ServicesService) {};
+
+  @Get()
+  async find(): Promise<Services[]> {
+    return this.servService.find();
+  }
+};

--- a/api/src/services/services.module.ts
+++ b/api/src/services/services.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { ServicesSchema } from 'src/models/services.schema';
+import { ServicesController } from './services.controller';
+import { ServicesService } from './services.service';
+
+@Module({
+  imports: [MongooseModule.forFeature([{ name: 'Services', schema: ServicesSchema }])],
+  controllers: [ServicesController],
+  providers: [ServicesService]
+})
+export class ServicesModule {}

--- a/api/src/services/services.service.spec.ts
+++ b/api/src/services/services.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ServicesService } from './services.service';
+
+describe('ServicesService', () => {
+  let service: ServicesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ServicesService],
+    }).compile();
+
+    service = module.get<ServicesService>(ServicesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/api/src/services/services.service.ts
+++ b/api/src/services/services.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { Services } from './entity/services.entity';
+import { Model } from 'mongoose';
+import { InjectModel } from '@nestjs/mongoose';
+
+@Injectable()
+export class ServicesService {
+  constructor(@InjectModel('Services') private readonly servicesModel: Model<Services>) {};
+
+  async find(): Promise<Services[]> {
+    return await this.servicesModel.find().populate('cards');
+  }
+}


### PR DESCRIPTION
# Services-Section API
## _Description_
 API to  retrieve Services-section from a mongodb database.
this is the first update to be compatible with the JSON server db. 

### Stack:
We used Nestjs - in typescript -and Mongodb as a databases.

### Request Body:
add a card:
```````
{
    "title":  "card-title",
    "description": "card-description"
}

```````
then add  services

```````
{
    "title":  "your-title",
    "cards": []
}

```````

### Requests:  
we have these requests available:
- GET `localhost:3001/services` to get about section

### Tasks to complete:
- [x] Services-Endpoints to db